### PR TITLE
[MP][OPS-6776] metrics collection

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,7 +62,6 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
 # Default HTTP client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 
-
 # Session Timeout
 # ~~~~
 # The default session timeout for the app is 15 minutes (900seconds).
@@ -100,14 +99,7 @@ play.http.router = prod.Routes
 
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis
-metrics {
-  name = ${appName}
-  rateUnit = SECONDS
-  durationUnit = SECONDS
-  showSamples = true
-  jvm = true
-  enabled = false
-}
+metrics.enabled = true
 
 mongodb {
   uri = "mongodb://localhost:27017/time-to-pay-arrangement"
@@ -119,7 +111,7 @@ mongodb {
 
 auditing {
   enabled = false
-  traceRequests = true
+  traceRequests = false
   consumer {
     baseUri {
       host = localhost

--- a/test/uk/gov/hmrc/timetopay/arrangement/services/CryptoServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopay/arrangement/services/CryptoServiceSpec.scala
@@ -19,11 +19,11 @@ package uk.gov.hmrc.timetopay.arrangement.services
 import org.scalatest.{FreeSpecLike, Matchers}
 import org.scalatestplus.play.guice.GuiceOneServerPerTest
 import uk.gov.hmrc.timetopay.arrangement.model.{BankDetails, DesSubmissionRequest, PaymentSchedule, SelfAssessment, TTPArrangement, Taxpayer}
-import uk.gov.hmrc.timetopay.arrangement.support.TestData
+import uk.gov.hmrc.timetopay.arrangement.support.{ITSpec, TestData}
 
 import java.time.LocalDate
 
-class CryptoServiceSpec extends FreeSpecLike with GuiceOneServerPerTest with Matchers with TestData {
+class CryptoServiceSpec extends ITSpec with TestData {
 
   val cryptoService = fakeApplication.injector.instanceOf[CryptoService]
 

--- a/test/uk/gov/hmrc/timetopay/arrangement/services/DesTTPArrangementBuilderSpec.scala
+++ b/test/uk/gov/hmrc/timetopay/arrangement/services/DesTTPArrangementBuilderSpec.scala
@@ -23,13 +23,11 @@ import play.api.Configuration
 
 import java.time.LocalDate
 import uk.gov.hmrc.timetopay.arrangement.model.TTPArrangement
-import uk.gov.hmrc.timetopay.arrangement.support.TestData
+import uk.gov.hmrc.timetopay.arrangement.support.{ITSpec, TestData}
 
-class DesTTPArrangementBuilderSpec extends FreeSpecLike with GuiceOneServerPerTest with Matchers with TestData {
+class DesTTPArrangementBuilderSpec extends ITSpec with TestData {
 
   import Taxpayers._
-
-  lazy val config = fakeApplication.injector.instanceOf[Configuration]
 
   private val desTTPArrangementService = new DesTTPArrangementBuilder(config)
   private val taxPayerData = Table(

--- a/test/uk/gov/hmrc/timetopay/arrangement/support/ITSpec.scala
+++ b/test/uk/gov/hmrc/timetopay/arrangement/support/ITSpec.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.timetopay.arrangement.support
 
+import com.codahale.metrics.SharedMetricRegistries
+
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import com.google.inject.AbstractModule
@@ -54,6 +56,11 @@ trait ITSpec
     LocalDateTime.parse("2018-11-02T16:28:55.185", formatter).atZone(ZoneId.of("Europe/London"))
   }
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    SharedMetricRegistries.clear()
+  }
+
   implicit lazy val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   lazy val overridingsModule = new AbstractModule {
     override def configure(): Unit = ()
@@ -76,6 +83,9 @@ trait ITSpec
     .overrides(GuiceableModule.fromGuiceModules(Seq(overridingsModule)))
     .configure(Map[String, Any](
       "mongodb.uri" -> mongoUri,
+      "metrics.enabled" -> false,
+      "metrics.jvm" -> false,
+      //      "microservice.metrics.graphite.enabled" -> false,
       "microservice.services.des-arrangement-api.host" -> "localhost",
       "microservice.services.des-arrangement-api.environment" -> "localhost",
       "microservice.services.des-arrangement-api.port" -> WireMockSupport.port)).build()


### PR DESCRIPTION
There is a now a coupling between auditing and metrics as we capture the number of audits attempted as a metric

The resulting message if auditing while metrics collection not enabled
https://kibana.tools.production.tax.service.gov.uk/app/kibana#/doc/match_all_logstash_ingested_logs_kibana_index_pattern/logstash-docker-000898/doc/?id=JenVSnwBznsWxXDljohN

https://hmrcdigital.slack.com/archives/C0J8C039C/p1619788493044800?thread_ts=1619785147.044100&cid=C0J8C039C